### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - Author: younatics
 - Git: https://github.com/younatics/YNDropDownMenu
 - Detail: The eligible dropdown menu, written in Swift 3, appears dropdown menu to display a view of related items when a user click on the dropdown menu. You can customize dropdown view whatever you like (e.g. UITableView, UICollectionView... etc)
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Menu
 
@@ -34,7 +34,7 @@
 - Author: Yalantis
 - Git: https://github.com/Yalantis/Side-Menu.iOS
 - Detail: Animated side menu with customizable UI. Made in Yalantis.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Menu
 
@@ -42,7 +42,7 @@
 - Author: Ramotion
 - Git: https://github.com/Ramotion/circle-menu
 - Detail: This project is maintained by Ramotion, Inc. We specialize in the designing and coding of custom UI for Mobile Apps and Websites.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Menu
 
@@ -50,7 +50,7 @@
 - Author: Yalantis
 - Git: https://github.com/Yalantis/GuillotineMenu
 - Detail: Our Guillotine Menu Transitioning Animation implemented in Swift reminds a bit of a notorious killing machine.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Menu
 
@@ -58,7 +58,7 @@
 - Author: jonkykong
 - Git: https://github.com/jonkykong/SideMenu
 - Detail: Simple side menu control for iOS in Swift inspired by Facebook. Right and Left sides. No coding required. iOS 8+.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Menu
 
@@ -66,7 +66,7 @@
 - Author: dekatotoro
 - Git: https://github.com/dekatotoro/SlideMenuControllerSwift
 - Detail: iOS Slide Menu View based on Google+, iQON, Feedly, Ameba iOS app. It is written in pure swift.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Menu
 
@@ -74,7 +74,7 @@
 - Author: Ramotion
 - Git: https://github.com/Ramotion/animated-tab-bar
 - Detail: RAMAnimatedTabBarController is a Swift module for adding animation to tabbar items.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Menu
 
@@ -84,7 +84,7 @@
 - Author: younatics
 - Git: https://github.com/younatics/Highlighter
 - Detail: Highlight whatever you want! Highlighter will magically find UI objects such as UILabel, UITextView, UITexTfield, UIButton in your UITableViewCell or other Class.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Animation
 
@@ -92,7 +92,7 @@
 - Author: Flipboard
 - Git: https://github.com/Flipboard/FLAnimatedImage
 - Detail: FLAnimatedImage is a performant animated GIF engine for iOS: 1. Plays multiple GIFs simultaneously with a playback speed comparable to desktop browsers 2. Honors variable frame delays 3. Behaves gracefully under memory pressure 4. Eliminates delays or blocking during the first playback loop 5. Interprets the frame delays of fast GIFs the same way modern browsers do
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Animation
 
@@ -100,7 +100,7 @@
 - Author: liyong03
 - Git: https://github.com/liyong03/YLGIFImage
 - Detail: Asynchronized GIF image class and Image viewer supporting play/stop GIF images. It just use very less memory. Following GIF usually will cost almost 600MB memory if it is fully decoded (800x600x389x4 Bytes), but using YLGIFImage, it just use about 30MB memory.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Animation
 
@@ -108,7 +108,7 @@
 - Author: AugustRush
 - Git: https://github.com/AugustRush/Stellar
 - Detail: A fantastic Physical animation library for swift(Not Just Spring !!!), it is base on UIDynamic and extension to it, friendly APIs make you use it or custom your own animation very easily!
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Animation
 
@@ -116,7 +116,7 @@
 - Author: exyte
 - Git: https://github.com/exyte/Macaw
 - Detail: Powerful and easy-to-use vector graphics Swift library with SVG support
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Animation
 
@@ -124,7 +124,7 @@
 - Author: cruisediary
 - Git: https://github.com/cruisediary/Pastel
 - Detail: Powerful and easy-to-use vector graphics Swift library with SVG support
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Animation
 
@@ -134,7 +134,7 @@
 - Author: shu223
 - Git: https://github.com/shu223/AnimatedTransitionGallery
 - Detail: Collection of custom animated transitions for iOS using UIViewControllerAnimatedTransitioning protocol.
-- Cocoapods: false
+- CocoaPods: false
 - Carthage: false
 - Type: Transition
 
@@ -142,7 +142,7 @@
 - Author: lkzhao
 - Git: https://github.com/lkzhao/Hero
 - Detail: Hero is a library for building iOS view controller transitions. It provides a layer on top of the UIKit's cumbersome transition APIs. Making custom transitions an easy task for developers.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Transition
 
@@ -150,7 +150,7 @@
 - Author: demonnico
 - Git: https://github.com/demonnico/PinterestSwift
 - Detail: This is a Swift based demo project to show how to make the transition Pinterest liked.
-- Cocoapods: false
+- CocoaPods: false
 - Carthage: false
 - Type: Transition
 
@@ -158,7 +158,7 @@
 - Author: jonathantribouharet
 - Git: https://github.com/jonathantribouharet/JTMaterialTransition
 - Detail: An iOS transition for controllers based on material design.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Transition
 
@@ -166,7 +166,7 @@
 - Author: entotsu
 - Git: https://github.com/entotsu/TKSubmitTransition
 - Detail: Animated UIButton of Loading Animation and Transition Animation.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Transition
 
@@ -174,7 +174,7 @@
 - Author: KelvinJin
 - Git: https://github.com/KelvinJin/AnimatedCollectionViewLayout
 - Detail: Animated UIButton of Loading Animation and Transition Animation.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Transition
 
@@ -182,7 +182,7 @@
 - Author: Ramotion
 - Git: https://github.com/Ramotion/preview-transition
 - Detail: PreviewTransition is a simple preview gallery controller
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Transition
 
@@ -190,7 +190,7 @@
 - Author: CezaryKopacz
 - Git: https://github.com/CezaryKopacz/CKWaveCollectionViewTransition
 - Detail: Cool wave like transition between two or more UICollectionView
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Transition
 
@@ -200,7 +200,7 @@
 - Author: younatics
 - Git: https://github.com/younatics/YNExpandableCell
 - Detail: Easiest usage of expandable & collapsible cell for iOS, written in Swift 3. You can customize expandable UITableViewCell whatever you like. YNExpandableCell is made because insertRows and deleteRows is hard to use. You can just inheirt YNTableViewDelegate and add one more method func tableView(_ tableView: YNTableView, expandCellAt indexPath) -> UITableViewCell?
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Tableview
 
@@ -208,7 +208,7 @@
 - Author: Yalantis
 - Git: https://github.com/Yalantis/Pull-to-Refresh.Rentals-iOS
 - Detail: This project aims to provide a simple and customizable pull to refresh implementation.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Tableview
 
@@ -216,7 +216,7 @@
 - Author: jerkoch
 - Git: https://github.com/jerkoch/SwipeCellKit
 - Detail: Swipeable UITableViewCell based on the stock Mail.app, implemented in Swift.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Tableview
 
@@ -224,7 +224,7 @@
 - Author: Ramotion
 - Git: https://github.com/Ramotion/folding-cell
 - Detail: FoldingCell is an expanding content cell inspired by folding paper material
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Tableview
 
@@ -232,7 +232,7 @@
 - Author: Ramotion
 - Git: https://github.com/Ramotion/elongation-preview
 - Detail: ElongationPreview is an elegant push-pop style view controller
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Tableview
 
@@ -242,7 +242,7 @@
 - Author: Ramotion
 - Git: https://github.com/Ramotion/expanding-collection
 - Detail: This project aims to provide a simple and customizable pull to refresh implementation.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Collectionview
 
@@ -250,7 +250,7 @@
 - Author: Yalantis
 - Git: https://github.com/Yalantis/Koloda
 - Detail: KolodaView is a class designed to simplify the implementation of Tinder like cards on iOS.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Collectionview
 
@@ -258,7 +258,7 @@
 - Author: MillmanY
 - Git: https://github.com/MillmanY/MMCardView
 - Detail: Custom CollectionView like Wallet App
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Collectionview
 
@@ -266,7 +266,7 @@
 - Author: CSStickyHeaderFlowLayout
 - Git: https://github.com/CSStickyHeaderFlowLayout/CSStickyHeaderFlowLayout
 - Detail: UICollectionView replacement of UITableView. Do even more like Parallax Header, Sticky Section Header. Made for iOS 7.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Collectionview
 
@@ -274,7 +274,7 @@
 - Author: gskbyte
 - Git: https://github.com/gskbyte/GSKStretchyHeaderView
 - Detail: GSKStretchyHeaderView is an implementation of the stretchy header paradigm as seen on many apps, like Twitter, Spotify or airbnb.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Collectionview
 
@@ -284,7 +284,7 @@
 - Author: ninjaprox
 - Git: https://github.com/ninjaprox/NVActivityIndicatorView
 - Detail: NVActivityIndicatorView is a collection of awesome loading animations.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Indicator
 
@@ -292,7 +292,7 @@
 - Author: TBXark
 - Git: https://github.com/TBXark/TKRubberIndicator
 - Detail: A rubber animation pagecontrol
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Indicator
 
@@ -300,7 +300,7 @@
 - Author: KyoheiG3
 - Git: https://github.com/KyoheiG3/SpringIndicator
 - Detail: SpringIndicator is indicator and PullToRefresh. Inspired by Material design components.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Indicator
 
@@ -309,7 +309,7 @@
 - Author: cruffenach
 - Git: https://github.com/cruffenach/CRToast
 - Detail: CRToast is a library that allows you to easily create notifications that appear on top of or by pushing out the status bar or navigation bar.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Alert
 
@@ -317,7 +317,7 @@
 - Author: sberrevoets
 - Git: https://github.com/sberrevoets/SDCAlertView
 - Detail: SDCAlertView started out as an alert that looked identical to UIAlertView, but had support for a custom content view. With the introduction of UIAlertController in iOS 8, the project was updated to the more modern API that UIAlertController brought.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Alert
 
@@ -325,7 +325,7 @@
 - Author: candostdagdeviren
 - Git: https://github.com/candostdagdeviren/CDAlertView
 - Detail: CDAlertView is highly customizable alert popup written in Swift 3. Usage is similar to UIAlertController.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Alert
 
@@ -333,7 +333,7 @@
 - Author: Orderella
 - Git: https://github.com/Orderella/PopupDialog
 - Detail: A simple, customizable popup dialog for iOS written in Swift. Replaces UIAlertController alert style.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Alert
 
@@ -341,7 +341,7 @@
 - Author: codestergit
 - Git: https://github.com/codestergit/SweetAlert-iOS
 - Detail: Beautiful Animated custom Alert View inspired from javascript library SweetAlert. Written in Swift this SweetAlertView can be used in Swift and Objective-C projects. SweetAlertView provides live intutive experience to user actions.It can be used in place of UIAlertView and UIAlertController
-- Cocoapods: false
+- CocoaPods: false
 - Carthage: false
 - Type: Alert
 
@@ -349,7 +349,7 @@
 - Author: entotsu
 - Git: https://github.com/entotsu/TKSwarmAlert
 - Detail: Animated alert library like Swarm app.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: Alert
 
@@ -357,7 +357,7 @@
 - Author: MarioIannotta
 - Git: https://github.com/MarioIannotta/MIBlurPopup
 - Detail: MIBlurPopup lets you create amazing popups with a blurred background
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: Alert
 
@@ -365,7 +365,7 @@
 - Author: AshRobinson
 - Git: https://github.com/AshRobinson/GoogleWearAlert
 - Detail: An Android Wear style confirmation view for iOS
-- Cocoapods: false
+- CocoaPods: false
 - Carthage: false
 - Type: Alert
 
@@ -375,7 +375,7 @@
 - Author: younatics
 - Git: https://github.com/younatics/YNSearch
 - Detail: Awesome search view, written in Swift 3, appears search view like Pinterest Search view. You can fully customize this library. You can also use this library with Realm!
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: UI
 
@@ -383,7 +383,7 @@
 - Author: IBAnimatable
 - Git: https://github.com/IBAnimatable/IBAnimatable
 - Detail: Design and prototype customized UI, interaction, navigation, transition and animation for App Store ready Apps in Interface Builder with IBAnimatable.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: UI
 
@@ -391,7 +391,7 @@
 - Author: Yalantis
 - Git: https://github.com/Yalantis/StarWars.iOS
 - Detail: This component implements transition animation to crumble view-controller into tiny pieces.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: false
 - Type: UI
 
@@ -399,7 +399,7 @@
 - Author: Yalantis
 - Git: https://github.com/Yalantis/Segmentio
 - Detail: Animated top/bottom segmented control written in Swift.
-- Cocoapods: true
+- CocoaPods: true
 - Carthage: true
 - Type: UI
 


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).
